### PR TITLE
画面更新時にオブジェクトが勝手に再整列されてしまう問題の修正

### DIFF
--- a/src/liveWPCGui/liveWPC_create_object.java
+++ b/src/liveWPCGui/liveWPC_create_object.java
@@ -11,6 +11,7 @@ public class liveWPC_create_object  extends JPanel{
 	public JLabel label;
 	public ImageIcon icon;
 	public boolean enableinfo;
+	public int x,y;
 	liveWPC_create_object(){
 		label = new JLabel();
 		this.setBackground(new Color(0,0,0,0));
@@ -51,8 +52,8 @@ public class liveWPC_create_object  extends JPanel{
 
 		public void mouseDragged(MouseEvent e) {
 			// マウスの座標からラベルの左上の座標を取得する
-			int x = e.getXOnScreen() - dx;
-			int y = e.getYOnScreen() - dy;
+			x = e.getXOnScreen() - dx;
+			y = e.getYOnScreen() - dy;
 			setLocation(x, y);
 		}
 
@@ -70,5 +71,12 @@ public class liveWPC_create_object  extends JPanel{
 		}
 
 	}
+    @Override
+    public void paint(Graphics g){
+        setLocation(x, y);
+        super.paint(g);
+    }
+
+
 
 }

--- a/src/liveWPCGui/liveWPC_create_object.java
+++ b/src/liveWPCGui/liveWPC_create_object.java
@@ -19,7 +19,8 @@ public class liveWPC_create_object  extends JPanel{
 		MyMouseListener listener = new MyMouseListener();
 		this.addMouseListener(listener);
 		this.addMouseMotionListener(listener);
-
+		x = 0;
+		y = 0;
 		//パネルに追加
 		this.add(label);
 	}
@@ -35,13 +36,13 @@ public class liveWPC_create_object  extends JPanel{
 			//ボーダーを青くする処理
 			LineBorder border = new LineBorder(Color.blue);
 			label.setBorder(border);
-			repaint();
+			//repaint();
 			enableinfo = true;
 		}else{
 			//ボーダーを透明化する処理
 			LineBorder border = new LineBorder(new Color(0,0,0,0));
 			label.setBorder(null);
-			repaint();
+			//repaint();
 			enableinfo = false;
 		}
 	}

--- a/src/liveWPCGui/liveWPC_main_window.java
+++ b/src/liveWPCGui/liveWPC_main_window.java
@@ -3,6 +3,7 @@ package liveWPCGui;
 import java.awt.*;
 
 import javax.swing.JPanel;
+import javax.swing.OverlayLayout;
 import javax.swing.border.LineBorder;
 
 public class liveWPC_main_window extends liveWPC_window_base{
@@ -15,33 +16,29 @@ public class liveWPC_main_window extends liveWPC_window_base{
 
 	liveWPC_main_window(){
 		//g = this.getGraphics();
-
-		tc = new liveWPC_create_object();
-		tc.setBounds(0,0,100,100);
-		tc.setPreferredSize(new Dimension(100,120));
-
-		border.setPreferredSize(new Dimension(225,400));
-		border.setOpaque(false);
-		LineBorder bordercolor = new LineBorder(Color.BLACK, 2, true);
-		border.setBorder(bordercolor);
-
 		tool_window= new liveWPC_tool_window();
 		proprety_window = new liveWPC_proprety_window();
 		proprety_window.call_proprety_window(1);//数字を変更することで表示する内容を変える。
 		//proprety_window.call_proprety_window(0);
 
 		panel.setPreferredSize(new Dimension(750,480));
-		//panel.setPreferredSize(new Dimension(225,400));
-		//panel.setLayout(new FlowLayout(FlowLayout.CENTER));
-		panel.setLayout(new FlowLayout());
+		panel.setLayout(null);
 		panel.setLocation(FlowLayout.CENTER,200);
 		panel.setBackground(Color.WHITE);
 		panel.setVisible(true);
-		panel.add(tc,BorderLayout.CENTER);
-		panel.add(border,BorderLayout.CENTER);
+
+		//border.setPreferredSize(new Dimension(225,400));
+		border.setOpaque(false);
+		LineBorder bordercolor = new LineBorder(Color.BLACK, 2, true);
+		border.setBorder(bordercolor);
+		border.setVisible(true);
+		border.setSize(225,400);
+		border.setLocation(262,0);
+
+		panel.add(border);
+
 
 		//getContentPane().countComponents();
-		//getContentPane().add(tc);
 		getContentPane().add(panel);
 
 
@@ -52,6 +49,11 @@ public class liveWPC_main_window extends liveWPC_window_base{
 		//proprety_window.change_font_type_box(false);
 
 	}
+    @Override
+    public void paint(Graphics g){
+        border.setLocation(262, 0);
+        super.paint(g);
+    }
 	public static void insert_circle(){
 		liveWPC_create_object tc = new liveWPC_create_object();
 	    panel.add(tc);
@@ -63,7 +65,7 @@ public class liveWPC_main_window extends liveWPC_window_base{
 
 	}
 	public static void insert_image(String imagepath){
-		liveWPC_create_object tc = new liveWPC_create_object(imagepath);
+		liveWPC_create_object tc = new liveWPC_create_image_object(imagepath);
 	    panel.add(tc);
 	    tc.setLocation(50, 50);
 	}


### PR DESCRIPTION
画面更新時にオブジェクトが勝手に再整列される問題を修正。

詳細はコミットコメント参照

https://livewpc.backlog.jp/view/LIVEWPC-13